### PR TITLE
Prevent spawning if agent exists

### DIFF
--- a/Config/UnrealGAMS-OSC.1.json
+++ b/Config/UnrealGAMS-OSC.1.json
@@ -226,7 +226,7 @@
               "default": 0,
               "value": "",
               "precision": 2,
-              "address": "/agent/1/yaw",
+              "address": "/agent/1/velocity/yaw",
               "preArgs": "",
               "target": "",
               "bypass": false,

--- a/Config/UnrealGAMS-OSC.2.json
+++ b/Config/UnrealGAMS-OSC.2.json
@@ -223,7 +223,7 @@
               "default": 0,
               "value": "",
               "precision": 2,
-              "address": "/agent/2/yaw/x",
+              "address": "/agent/2/velocity/yaw",
               "preArgs": "",
               "target": "",
               "bypass": false,

--- a/Content/Blueprints/Simulation.uasset
+++ b/Content/Blueprints/Simulation.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:023e7dccaee6288796499e33cdc0f0c560c2e84b3bc42dddeb6607420ee7b7bf
-size 112789
+oid sha256:3b7ce10e90481068e792af89a36416bf74c65aa8bcb783686a7ddc8d412b9d54
+size 165562

--- a/Content/Robots/Quadcopters/Blueprints/Quadcopter.uasset
+++ b/Content/Robots/Quadcopters/Blueprints/Quadcopter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:774d601f09be4162d92f14eb4729b6ac3e80d81a44eaf1d4aa102abec5f1186d
-size 541323
+oid sha256:fccd5cc00e9faeee35d0a6088c8ec1697bb834ee64946023230ea98adc17f708
+size 542161

--- a/Content/Robots/Quadcopters/Blueprints/Quadcopter.uasset
+++ b/Content/Robots/Quadcopters/Blueprints/Quadcopter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fccd5cc00e9faeee35d0a6088c8ec1697bb834ee64946023230ea98adc17f708
-size 542161
+oid sha256:601a804fe758d998af7c08bf28acdc895657ef449dfdb8833949b07787635a68
+size 543794


### PR DESCRIPTION
- Prevent spawning quadcopter if Id and Port already exist.
- Solved issues caused by **Spawn collision habdling method*.
- Updated OSC example controls for agent 1 and 2.