### PR TITLE
SimPawn and Quadcopter audio removed

### DIFF
--- a/Content/Blueprints/BP_Simulation.uasset
+++ b/Content/Blueprints/BP_Simulation.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:45d25cd0cf157f2903ac302bca283f41b76ea6c918a3f2fd2c975b8001cfbc5b
-size 244287
+oid sha256:90f282c69d2fa738f5ac088aaee1f980a5b3d1d0aafe3c0079aa9744b747f943
+size 243060

--- a/Content/Common/Blueprints/SimPawn.uasset
+++ b/Content/Common/Blueprints/SimPawn.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:deabdfff75a11e56358df4cc17d402a07c8d0cb76d41826b058721d6cab01f3a
+size 15125

--- a/Content/Robots/Quadcopter/Blueprints/BP_Quadcopter.uasset
+++ b/Content/Robots/Quadcopter/Blueprints/BP_Quadcopter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2366a84c02525cfd02874fdf4fef0aacfe7b211238de39d6acfda64ddc3bbdf1
-size 563339
+oid sha256:acabaad4ab299463c31f3f3683e789b89bacc46f5c333b51b20f2b1c0b4b5fa8
+size 558717

--- a/Content/Robots/Quadcopter/Blueprints/BP_Quadcopter.uasset
+++ b/Content/Robots/Quadcopter/Blueprints/BP_Quadcopter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:acabaad4ab299463c31f3f3683e789b89bacc46f5c333b51b20f2b1c0b4b5fa8
-size 558717
+oid sha256:d3830122a340064b415fa02949a68192ba87d0840d5f386071fbdb78abf4571a
+size 528654

--- a/Content/Robots/Quadcopter/Maps/MAP_Quadcopter.umap
+++ b/Content/Robots/Quadcopter/Maps/MAP_Quadcopter.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:06070b24a3562c267db59211fe37e53d1b517fef820cd25e4ed3d51c2cc54d19
-size 92650
+oid sha256:f87965298e19a220fc30232dde8393ebd8245dc1902cbc885d11758d4e0a6242
+size 92648

--- a/Content/Robots/Satellite/Blueprints/BP_Satellite.uasset
+++ b/Content/Robots/Satellite/Blueprints/BP_Satellite.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd175a7121eed4e0e77ab17936e68015bf1768543b3d328e1d3ade4478d9c508
-size 275773
+oid sha256:3ce8c49fd2e8b1d843fb5edb1e3db57116d0989aebb4a83453ecc2ab9b82e8a2
+size 270297

--- a/Plugins/OSC/Content/Blueprints/OSCPawn.uasset
+++ b/Plugins/OSC/Content/Blueprints/OSCPawn.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8ba7cebe0b3fb232cbd4ca828c3db19a9fbc1c0fb9a3b2ce7ba1b8813f6f172b
-size 17652


### PR DESCRIPTION
- OSCPawn refactored and renamed SimPawn.
- Quadcopter audio removed.
- Quadcopter outputs fixed.